### PR TITLE
fixboproductname: safer install, type casting, SQL fix, README and fa translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # fixboproductname
-Prestashop Module - fix BackOffice product name for Disabled languages
+
+PrestaShop module that keeps Back Office product names usable when one or more languages are disabled.
+
+## What it does
+
+PrestaShop can still keep product rows for disabled languages in `product_lang`. This module copies each product name from the shop default language into disabled-language rows so the Back Office shows a valid product name instead of an empty or stale value.
+
+The module runs in two situations:
+
+- On installation, it processes existing products once.
+- On product update, it listens to `actionProductUpdate` and updates that product's disabled-language names.
+
+## Compatibility
+
+- Minimum PrestaShop version: 1.6
+- Maximum PrestaShop version: current installed `_PS_VERSION_`
+- Multi-shop aware: updates are scoped to the current shop ID.
+
+## Installation
+
+1. Back up your database before installing, especially on large catalogs.
+2. Copy the `fixboproductname` folder into the PrestaShop `modules` directory.
+3. Install the module from the Back Office modules page.
+
+## Notes and limitations
+
+- Installation updates existing products immediately. On very large catalogs this may take time, so install during a maintenance window if needed.
+- If there are no disabled languages for the current shop, the module skips the update safely.
+- The module has no configuration screen.

--- a/config.xml
+++ b/config.xml
@@ -2,10 +2,10 @@
 <module>
 	<name>fixboproductname</name>
 	<displayName><![CDATA[Fixed BackOffice product name]]></displayName>
-	<version><![CDATA[1.0.0]]></version>
+	<version><![CDATA[1.0.1]]></version>
 	<description><![CDATA[Fixed BackOffice product name for disabled languages]]></description>
 	<author><![CDATA[Saeed Sattar Beglou]]></author>
 	<tab><![CDATA[administration]]></tab>
 	<is_configurable>0</is_configurable>
-	<need_instance>1</need_instance>
+	<need_instance>0</need_instance>
 </module>

--- a/fixboproductname.php
+++ b/fixboproductname.php
@@ -36,7 +36,7 @@ class Fixboproductname extends Module
     {
         $this->name = 'fixboproductname';
         $this->tab = 'administration';
-        $this->version = '1.0.0';
+        $this->version = '1.0.1';
         $this->author = 'Saeed Sattar Beglou';
         $this->need_instance = 0;
 
@@ -55,10 +55,17 @@ class Fixboproductname extends Module
 
     public function install()
     {
-        $this->fixAllProductName();
+        if (!parent::install() || !$this->registerHook('actionProductUpdate')) {
+            return false;
+        }
 
-        return parent::install() &&
-            $this->registerHook('actionProductUpdate');
+        if (!$this->fixAllProductName()) {
+            $this->uninstall();
+
+            return false;
+        }
+
+        return true;
     }
 
     public function uninstall()
@@ -72,45 +79,63 @@ class Fixboproductname extends Module
             return;
         }
 
-        $id_shop = $this->context->shop->id;
-        $id_default_lang = Configuration::get('PS_LANG_DEFAULT', null, null, $id_shop);
-        $this->fixProductName($params['id_product'], $id_default_lang, $id_shop);
+        $id_shop = (int) $this->context->shop->id;
+        $id_default_lang = (int) Configuration::get('PS_LANG_DEFAULT', null, null, $id_shop);
+        $this->fixProductName((int) $params['id_product'], $id_default_lang, $id_shop);
     }
 
     public function fixProductName($id_product, $id_default_lang, $id_shop)
     {
-        $disabled_lang_id = $this->getDisabledLangs($id_shop);
+        $id_product = (int) $id_product;
+        $id_default_lang = (int) $id_default_lang;
+        $id_shop = (int) $id_shop;
+        $disabled_lang_ids = $this->getDisabledLangs($id_shop);
 
-        $sql = "UPDATE `" . _DB_PREFIX_ . "product_lang` a
-                INNER JOIN (SELECT b.name, b.id_lang FROM `" . _DB_PREFIX_ . "product_lang` b WHERE b.id_lang = ". $id_default_lang ." AND b.id_product = ". $id_product ." AND id_shop = " . $id_shop . ") t ON
-                a.id_product = " . $id_product . " AND a.id_lang IN ('". $disabled_lang_id ."') AND id_shop = " . $id_shop . "
-                SET a.name=t.name";
+        if (empty($disabled_lang_ids)) {
+            return true;
+        }
 
-        return Db::getInstance()->Execute($sql);
+        $sql = 'UPDATE `' . _DB_PREFIX_ . 'product_lang` a
+                INNER JOIN (
+                    SELECT b.name
+                    FROM `' . _DB_PREFIX_ . 'product_lang` b
+                    WHERE b.id_lang = ' . $id_default_lang . '
+                        AND b.id_product = ' . $id_product . '
+                        AND b.id_shop = ' . $id_shop . '
+                ) t ON a.id_product = ' . $id_product . '
+                    AND a.id_lang IN (' . implode(',', $disabled_lang_ids) . ')
+                    AND a.id_shop = ' . $id_shop . '
+                SET a.name = t.name';
+
+        return Db::getInstance()->execute($sql);
     }
 
     public function getDisabledLangs($id_shop)
     {
-        $id_langs = Language::getLanguages(false, $id_shop);
+        $id_langs = Language::getLanguages(false, (int) $id_shop);
 
         $disabledLangs = array();
         foreach ($id_langs as $id_lang) {
-            if ($id_lang['active'] == 0) {
-                array_push($disabledLangs, $id_lang['id_lang']);
+            if ((int) $id_lang['active'] === 0) {
+                $disabledLangs[] = (int) $id_lang['id_lang'];
             }
         }
 
-        return implode("','", $disabledLangs);
+        return $disabledLangs;
     }
 
     public function fixAllProductName()
     {
-        $id_shop = $this->context->shop->id;
-        $id_default_lang = Configuration::get('PS_LANG_DEFAULT', null, null, $id_shop);
+        $id_shop = (int) $this->context->shop->id;
+        $id_default_lang = (int) Configuration::get('PS_LANG_DEFAULT', null, null, $id_shop);
 
         $products = Product::getProducts($id_default_lang, 1, 0, 'name', 'ASC', false, false);
         foreach ($products as $key) {
-            $this->fixProductName($key['id_product'], $id_default_lang, $id_shop);
+            if (!$this->fixProductName((int) $key['id_product'], $id_default_lang, $id_shop)) {
+                return false;
+            }
         }
+
+        return true;
     }
 }

--- a/translations/fa.php
+++ b/translations/fa.php
@@ -1,0 +1,6 @@
+<?php
+
+global $_MODULE;
+$_MODULE = array();
+$_MODULE['<{fixboproductname}prestashop>fixboproductname_f95dd7bd7ccd9f12844cb0166b18ea88'] = 'اصلاح نام محصول در مدیریت';
+$_MODULE['<{fixboproductname}prestashop>fixboproductname_f360550cea4991c8706616734c1b080d'] = 'اصلاح نام محصول در مدیریت برای زبان‌های غیرفعال';


### PR DESCRIPTION
### Motivation

- Ensure Back Office product names remain usable for disabled languages and make installation resilient on large catalogs.  
- Improve robustness by validating and casting inputs and avoiding SQL errors when no disabled languages exist.  

### Description

- Bumped module version to `1.0.1` and set `<need_instance>`/`$this->need_instance` to `0`.  
- Installation now registers the `actionProductUpdate` hook, runs `fixAllProductName()` during install, and uninstalls/aborts if the mass update fails.  
- Hardened `hookActionProductUpdate`, `fixProductName`, `getDisabledLangs`, and `fixAllProductName` with explicit `(int)` casts, empty-set checks, and safer SQL that uses `implode(',', $disabled_lang_ids)` and `Db::getInstance()->execute()`.  
- Added documentation to `README.md` and a Persian translation file `translations/fa.php`.  

### Testing

- Ran PHP syntax checks with `php -l` on modified PHP files and they succeeded.  
- Validated `config.xml` with `xmllint --noout` and it passed XML validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1be7a71c74832f8c4b9443f0509c2e)